### PR TITLE
mongo: trace all with OpenCensus

### DIFF
--- a/core/auth/default.go
+++ b/core/auth/default.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
 	"github.com/mongodb/mongo-go-driver/internal/feature"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 func newDefaultAuthenticator(cred *Cred) (Authenticator, error) {
@@ -28,6 +29,9 @@ type DefaultAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *DefaultAuthenticator) Auth(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var actual Authenticator
 	var err error
 	if err = feature.ScramSHA1(desc.Version); err != nil {

--- a/core/auth/mongodbcr.go
+++ b/core/auth/mongodbcr.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // MONGODBCR is the mechanism name for MONGODB-CR.
@@ -39,6 +40,9 @@ type MongoDBCRAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *MongoDBCRAuthenticator) Auth(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	// Arbiters cannot be authenticated
 	if desc.Kind == description.RSArbiter {

--- a/core/auth/plain.go
+++ b/core/auth/plain.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // PLAIN is the mechanism name for PLAIN.
@@ -36,6 +37,9 @@ type PlainAuthenticator struct {
 
 // Auth authenticates the connection.
 func (a *PlainAuthenticator) Auth(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return ConductSaslConversation(ctx, desc, rw, "$external", &plainSaslClient{
 		username: a.Username,
 		password: a.Password,

--- a/core/auth/sasl.go
+++ b/core/auth/sasl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // SaslClient is the client piece of a sasl conversation.
@@ -30,6 +31,9 @@ type SaslClientCloser interface {
 
 // ConductSaslConversation handles running a sasl conversation with MongoDB.
 func ConductSaslConversation(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter, db string, client SaslClient) error {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	// Arbiters cannot be authenticated
 	if desc.Kind == description.RSArbiter {

--- a/core/auth/scramsha1.go
+++ b/core/auth/scramsha1.go
@@ -11,18 +11,18 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"math/rand"
 	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
-	"golang.org/x/crypto/pbkdf2"
-
-	"strings"
-
-	"encoding/base64"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // SCRAMSHA1 is the mechanism name for SCRAM-SHA-1.
@@ -51,6 +51,9 @@ type ScramSHA1Authenticator struct {
 
 // Auth authenticates the connection.
 func (a *ScramSHA1Authenticator) Auth(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	client := &scramSaslClient{
 		username:       a.Username,
 		password:       a.Password,

--- a/core/auth/x509.go
+++ b/core/auth/x509.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // MongoDBX509 is the mechanism name for MongoDBX509.
@@ -29,6 +30,9 @@ type MongoDBX509Authenticator struct {
 
 // Auth implements the Authenticator interface.
 func (a *MongoDBX509Authenticator) Auth(ctx context.Context, desc description.Server, rw wiremessage.ReadWriter) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	authRequestDoc := bson.NewDocument(
 		bson.EC.Int32("authenticate", 1),
 		bson.EC.String("mechanism", MongoDBX509),

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,0 +1,80 @@
+// Copyright (C) MongoDB, Inc. 2018-present.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+package trace
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+
+	"go.opencensus.io/trace"
+)
+
+// The purpose of baseCommonName is to help trim out the Longest Common Prefix
+// so that different spans will have disambiguated names e.g.
+//    mongo.(*Collection).InsertOne
+// instead of:
+//    github.com/mongodb/mongo-go-driver/mongo.(*Collection).InsertOne
+// in a non-invasive way.
+func caller0() string {
+	pc, _, _, _ := runtime.Caller(0)
+	fn := runtime.FuncForPC(pc)
+	return fn.Name()
+}
+
+var baseCommonPath = caller0()
+
+var lcpCacheMtx sync.Mutex
+var lcpCache = make(map[string]string)
+
+func longestCommonPrefix(p1, p2 string) string {
+	min, max := p1, p2
+	if len(max) < len(min) {
+		min, max = max, min
+	}
+	for i := 0; i < len(min); i++ {
+		if max[i] != min[i] {
+			return min[:i]
+		}
+	}
+	return min
+}
+
+func SpanFromFunctionCaller(ctx context.Context) (context.Context, *trace.Span) {
+	// The call to relativeName is an extra
+	// function call away from the original, hence 2.
+	return trace.StartSpan(ctx, relativeName(2))
+}
+
+func SpanWithName(ctx context.Context, name string) (context.Context, *trace.Span) {
+	return trace.StartSpan(ctx, name)
+}
+
+func RelativeName() string {
+	// The call to relativeName is an extra
+	// function call away from the original, hence 2.
+	return relativeName(2)
+}
+
+func relativeName(nCaller int) string {
+	pc, _, _, _ := runtime.Caller(nCaller)
+	fn := runtime.FuncForPC(pc)
+	fnName := fn.Name()
+	lcpName, ok := lcpCache[fnName]
+
+	if !ok {
+		lcpCacheMtx.Lock()
+		disambiguatedPrefix := longestCommonPrefix(baseCommonPath, fnName)
+		trimmed := strings.TrimPrefix(fnName, disambiguatedPrefix)
+		lcpCache[fnName] = trimmed
+		lcpName = trimmed
+		lcpCacheMtx.Unlock()
+	}
+
+	return lcpName
+}

--- a/mongo/client.go
+++ b/mongo/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/readpref"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 const defaultLocalThreshold = 15 * time.Millisecond
@@ -147,6 +148,9 @@ func (client *Client) ConnectionString() string {
 func (client *Client) listDatabasesHelper(ctx context.Context, filter interface{},
 	nameOnly bool) (ListDatabasesResult, error) {
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return ListDatabasesResult{}, err
@@ -171,11 +175,17 @@ func (client *Client) listDatabasesHelper(ctx context.Context, filter interface{
 
 // ListDatabases returns a ListDatabasesResult.
 func (client *Client) ListDatabases(ctx context.Context, filter interface{}) (ListDatabasesResult, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return client.listDatabasesHelper(ctx, filter, false)
 }
 
 // ListDatabaseNames returns a slice containing the names of all of the databases on the server.
 func (client *Client) ListDatabaseNames(ctx context.Context, filter interface{}) ([]string, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	res, err := client.listDatabasesHelper(ctx, filter, true)
 	if err != nil {
 		return nil, err

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/readpref"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Collection performs operations on a given collection.
@@ -74,6 +75,9 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	doc, err := TransformDocument(document)
 	if err != nil {
 		return nil, err
@@ -119,6 +123,9 @@ func (coll *Collection) InsertMany(ctx context.Context, documents []interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	result := make([]interface{}, len(documents))
 	docs := make([]*bson.Document, len(documents))
@@ -169,6 +176,9 @@ func (coll *Collection) DeleteOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -207,6 +217,9 @@ func (coll *Collection) DeleteMany(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -233,6 +246,9 @@ func (coll *Collection) updateOrReplaceOne(ctx context.Context, filter,
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	updateDocs := []*bson.Document{
 		bson.NewDocument(
@@ -278,6 +294,9 @@ func (coll *Collection) UpdateOne(ctx context.Context, filter interface{}, updat
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -307,6 +326,9 @@ func (coll *Collection) UpdateMany(ctx context.Context, filter interface{}, upda
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -367,6 +389,9 @@ func (coll *Collection) ReplaceOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return nil, err
@@ -404,6 +429,9 @@ func (coll *Collection) Aggregate(ctx context.Context, pipeline interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	pipelineArr, err := transformAggregatePipeline(pipeline)
 	if err != nil {
 		return nil, err
@@ -431,6 +459,9 @@ func (coll *Collection) Count(ctx context.Context, filter interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -460,6 +491,9 @@ func (coll *Collection) Distinct(ctx context.Context, fieldName string, filter i
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	var f *bson.Document
 	var err error
@@ -498,6 +532,9 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	var f *bson.Document
 	var err error
@@ -539,6 +576,9 @@ func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var f *bson.Document
 	var err error
 	if filter != nil {
@@ -579,6 +619,9 @@ func (coll *Collection) FindOneAndDelete(ctx context.Context, filter interface{}
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var f *bson.Document
 	var err error
 	if filter != nil {
@@ -617,6 +660,9 @@ func (coll *Collection) FindOneAndReplace(ctx context.Context, filter interface{
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	f, err := TransformDocument(filter)
 	if err != nil {
@@ -663,6 +709,9 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 		ctx = context.Background()
 	}
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	f, err := TransformDocument(filter)
 	if err != nil {
 		return &DocumentResult{err: err}
@@ -697,6 +746,9 @@ func (coll *Collection) FindOneAndUpdate(ctx context.Context, filter interface{}
 // supports resumability in the case of some errors.
 func (coll *Collection) Watch(ctx context.Context, pipeline interface{},
 	opts ...options.ChangeStreamOptioner) (Cursor, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return newChangeStream(ctx, coll, pipeline, opts...)
 }
 

--- a/mongo/database.go
+++ b/mongo/database.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/readpref"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Database performs operations on a given database.
@@ -70,6 +71,9 @@ func (db *Database) RunCommand(ctx context.Context, runCommand interface{}) (bso
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	cmd := command.Command{DB: db.Name(), Command: runCommand}
 	return dispatch.Command(ctx, cmd, db.client.topology, topology.ReadPrefSelector(readpref.Primary()))

--- a/mongo/index_view.go
+++ b/mongo/index_view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/bson"
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/dispatch"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ErrInvalidIndexValue indicates that the index Keys document has a value that isn't either a number or a string.
@@ -33,6 +34,9 @@ type IndexModel struct {
 
 // List returns a cursor iterating over all the indexes in the collection.
 func (iv IndexView) List(ctx context.Context) (Cursor, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	listCmd := command.ListIndexes{NS: iv.coll.namespace()}
 
 	return dispatch.ListIndexes(ctx, listCmd, iv.coll.client.topology, iv.coll.writeSelector)
@@ -40,6 +44,9 @@ func (iv IndexView) List(ctx context.Context) (Cursor, error) {
 
 // CreateOne creates a single index in the collection specified by the model.
 func (iv IndexView) CreateOne(ctx context.Context, model IndexModel) (string, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	names, err := iv.CreateMany(ctx, model)
 	if err != nil {
 		return "", err
@@ -51,6 +58,9 @@ func (iv IndexView) CreateOne(ctx context.Context, model IndexModel) (string, er
 // CreateMany creates multiple indexes in the collection specified by the models. The names of the
 // creates indexes are returned.
 func (iv IndexView) CreateMany(ctx context.Context, models ...IndexModel) ([]string, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	names := make([]string, 0, len(models))
 	indexes := bson.NewArray()
 
@@ -88,6 +98,9 @@ func (iv IndexView) CreateMany(ctx context.Context, models ...IndexModel) ([]str
 
 // DropOne drops the index with the given name from the collection.
 func (iv IndexView) DropOne(ctx context.Context, name string) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if name == "*" {
 		return nil, ErrMultipleIndexDrop
 	}
@@ -99,6 +112,9 @@ func (iv IndexView) DropOne(ctx context.Context, name string) (bson.Reader, erro
 
 // DropAll drops all indexes in the collection.
 func (iv IndexView) DropAll(ctx context.Context) (bson.Reader, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	cmd := command.DropIndexes{NS: iv.coll.namespace(), Index: "*"}
 
 	return dispatch.DropIndexes(ctx, cmd, iv.coll.client.topology, iv.coll.writeSelector)


### PR DESCRIPTION
Add non-invasive tracing with OpenCensus, thankfully
because these functions had a forethought of using context.Context
so internally we just plug in:

```go
ctx, span := startSpan(ctx)
defer span.End()
```