### PR TITLE
all: refurbrish with OpenCensus instrumentation

### DIFF
--- a/core/command/insert.go
+++ b/core/command/insert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/options"
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Insert represents the insert command.
@@ -70,6 +71,9 @@ func (i *Insert) Err() error { return i.err }
 
 // RoundTrip handles the execution of this command using the provided wiremessage.ReadWriter.
 func (i *Insert) RoundTrip(ctx context.Context, desc description.SelectedServer, rw wiremessage.ReadWriter) (result.Insert, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	wm, err := i.Encode(desc)
 	if err != nil {
 		return result.Insert{}, err

--- a/core/connection/connection.go
+++ b/core/connection/connection.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/addr"
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 var globalClientConnectionID uint64
@@ -63,6 +64,9 @@ type HandshakerFunc func(context.Context, addr.Addr, wiremessage.ReadWriter) (de
 
 // Handshake implements the Handshaker interface.
 func (hf HandshakerFunc) Handshake(ctx context.Context, address addr.Addr, rw wiremessage.ReadWriter) (description.Server, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	return hf(ctx, address, rw)
 }
 

--- a/core/connection/pool.go
+++ b/core/connection/pool.go
@@ -6,9 +6,11 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"golang.org/x/sync/semaphore"
+
 	"github.com/mongodb/mongo-go-driver/core/addr"
 	"github.com/mongodb/mongo-go-driver/core/description"
-	"golang.org/x/sync/semaphore"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ErrPoolClosed is returned from an attempt to use a closed pool.
@@ -81,6 +83,9 @@ func (p *pool) Close() error {
 }
 
 func (p *pool) Get(ctx context.Context) (Connection, *description.Server, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	p.Lock()
 	conns := p.conns
 	p.Unlock()

--- a/core/dispatch/aggregate.go
+++ b/core/dispatch/aggregate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/options"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Aggregate handles the full cycle dispatch and execution of an aggregate command against the provided
@@ -18,6 +19,9 @@ func Aggregate(
 	readSelector, writeSelector topology.ServerSelector,
 	wc *writeconcern.WriteConcern,
 ) (command.Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	dollarOut := cmd.HasDollarOut()
 

--- a/core/dispatch/command.go
+++ b/core/dispatch/command.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/bson"
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Command handles the full cycle dispatch and execution of a command against the provided
@@ -16,6 +17,9 @@ func Command(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/count.go
+++ b/core/dispatch/count.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/readconcern"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Count handles the full cycle dispatch and execution of a count command against the provided
@@ -17,6 +18,9 @@ func Count(
 	selector topology.ServerSelector,
 	rc *readconcern.ReadConcern,
 ) (int64, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/create_indexes.go
+++ b/core/dispatch/create_indexes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // CreateIndexes handles the full cycle dispatch and execution of a createIndexes
@@ -16,6 +17,9 @@ func CreateIndexes(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (result.CreateIndexes, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/delete.go
+++ b/core/dispatch/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Delete handles the full cycle dispatch and execution of a delete command against the provided
@@ -19,6 +20,9 @@ func Delete(
 	selector topology.ServerSelector,
 	wc *writeconcern.WriteConcern,
 ) (result.Delete, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/delete_indexes.go
+++ b/core/dispatch/delete_indexes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/bson"
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // DropIndexes handles the full cycle dispatch and execution of a dropIndexes
@@ -16,6 +17,9 @@ func DropIndexes(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (bson.Reader, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/distinct.go
+++ b/core/dispatch/distinct.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/readconcern"
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Distinct handles the full cycle dispatch and execution of a distinct command against the provided
@@ -18,6 +19,9 @@ func Distinct(
 	selector topology.ServerSelector,
 	rc *readconcern.ReadConcern,
 ) (result.Distinct, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/find.go
+++ b/core/dispatch/find.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/readconcern"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Find handles the full cycle dispatch and execution of a find command against the provided
@@ -18,13 +19,18 @@ func Find(
 	rc *readconcern.ReadConcern,
 ) (command.Cursor, error) {
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {
 		return nil, err
 	}
 
 	if rc != nil {
+		_, rSpan := trace.SpanWithName(ctx, "readConcernOption")
 		opt, err := readConcernOption(rc)
+		rSpan.End()
 		if err != nil {
 			return nil, err
 		}
@@ -32,7 +38,10 @@ func Find(
 	}
 
 	desc := ss.Description()
+	_, cSpan := trace.SpanWithName(ctx, "ss.Connection")
 	conn, err := ss.Connection(ctx)
+	cSpan.End()
+
 	if err != nil {
 		return nil, err
 	}

--- a/core/dispatch/find_one_and_delete.go
+++ b/core/dispatch/find_one_and_delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // FindOneAndDelete handles the full cycle dispatch and execution of a FindOneAndDelete command against the provided
@@ -20,13 +21,18 @@ func FindOneAndDelete(
 	wc *writeconcern.WriteConcern,
 ) (result.FindAndModify, error) {
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {
 		return result.FindAndModify{}, err
 	}
 
 	if wc != nil {
+		_, wcSpan := trace.SpanWithName(ctx, "writeConcernOption")
 		opt, err := writeConcernOption(wc)
+		wcSpan.End()
 		if err != nil {
 			return result.FindAndModify{}, err
 		}

--- a/core/dispatch/find_one_and_update.go
+++ b/core/dispatch/find_one_and_update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // FindOneAndUpdate handles the full cycle dispatch and execution of a FindOneAndUpdate command against the provided
@@ -20,13 +21,18 @@ func FindOneAndUpdate(
 	wc *writeconcern.WriteConcern,
 ) (result.FindAndModify, error) {
 
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {
 		return result.FindAndModify{}, err
 	}
 
 	if wc != nil {
+		_, wcSpan := trace.SpanWithName(ctx, "writeConcernOption")
 		opt, err := writeConcernOption(wc)
+		wcSpan.End()
 		if err != nil {
 			return result.FindAndModify{}, err
 		}

--- a/core/dispatch/insert.go
+++ b/core/dispatch/insert.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Insert handles the full cycle dispatch and execution of an insert command against the provided
@@ -19,6 +20,9 @@ func Insert(
 	selector topology.ServerSelector,
 	wc *writeconcern.WriteConcern,
 ) (result.Insert, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/list_collections.go
+++ b/core/dispatch/list_collections.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ListCollections handles the full cycle dispatch and execution of a listCollections command against the provided
@@ -15,6 +16,9 @@ func ListCollections(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (command.Cursor, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/list_databases.go
+++ b/core/dispatch/list_databases.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ListDatabases handles the full cycle dispatch and execution of a listDatabases command against the provided
@@ -16,6 +17,9 @@ func ListDatabases(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (result.ListDatabases, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/list_indexes.go
+++ b/core/dispatch/list_indexes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/core/command"
 	"github.com/mongodb/mongo-go-driver/core/topology"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ListIndexes handles the full cycle dispatch and execution of a listIndexes command against the provided
@@ -15,6 +16,8 @@ func ListIndexes(
 	topo *topology.Topology,
 	selector topology.ServerSelector,
 ) (command.Cursor, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/dispatch/update.go
+++ b/core/dispatch/update.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/result"
 	"github.com/mongodb/mongo-go-driver/core/topology"
 	"github.com/mongodb/mongo-go-driver/core/writeconcern"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // Update handles the full cycle dispatch and execution of an update command against the provided
@@ -19,6 +20,9 @@ func Update(
 	selector topology.ServerSelector,
 	wc *writeconcern.WriteConcern,
 ) (result.Update, error) {
+
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
 
 	ss, err := topo.SelectServer(ctx, selector)
 	if err != nil {

--- a/core/topology/connection.go
+++ b/core/topology/connection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/core/connection"
 	"github.com/mongodb/mongo-go-driver/core/wiremessage"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // sconn is a wrapper around a connection.Connection. This type is returned by
@@ -18,6 +19,9 @@ type sconn struct {
 }
 
 func (sc *sconn) ReadWireMessage(ctx context.Context) (wiremessage.WireMessage, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if sc.Connection == nil {
 		return nil, errors.New("already closed")
 	}
@@ -27,6 +31,9 @@ func (sc *sconn) ReadWireMessage(ctx context.Context) (wiremessage.WireMessage, 
 }
 
 func (sc *sconn) WriteWireMessage(ctx context.Context, wm wiremessage.WireMessage) error {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	if sc.Connection == nil {
 		return errors.New("already closed")
 	}

--- a/core/topology/server.go
+++ b/core/topology/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mongodb/mongo-go-driver/core/description"
 	"github.com/mongodb/mongo-go-driver/core/options"
 	"github.com/mongodb/mongo-go-driver/core/result"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 const minHeartbeatInterval = 500 * time.Millisecond
@@ -108,7 +109,12 @@ func (s *Server) Close() error {
 
 // Connection gets a connection to the server.
 func (s *Server) Connection(ctx context.Context) (connection.Connection, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
+	_, connSpan := trace.SpanWithName(ctx, "s.pool.Get")
 	conn, desc, err := s.pool.Get(ctx)
+	connSpan.End()
 	if err != nil {
 		return nil, err
 	}

--- a/core/topology/topology.go
+++ b/core/topology/topology.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mongodb/mongo-go-driver/core/addr"
 	"github.com/mongodb/mongo-go-driver/core/description"
+	"github.com/mongodb/mongo-go-driver/internal/trace"
 )
 
 // ErrSubscribeAfterClosed is returned when a user attempts to subscribe to a
@@ -186,6 +187,9 @@ func (t *Topology) RequestImmediateCheck() {
 // server selection spec, and will time out after severSelectionTimeout or when the
 // parent context is done.
 func (t *Topology) SelectServer(ctx context.Context, ss ServerSelector) (*SelectedServer, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var ssTimeoutCh <-chan time.Time
 
 	if t.cfg.serverSelectionTimeout > 0 {
@@ -242,6 +246,9 @@ func (t *Topology) findServer(selected description.Server) (*SelectedServer, err
 // selectServer is the core piece of server selection. It handles getting
 // topology descriptions and running sever selection on those descriptions.
 func (t *Topology) selectServer(ctx context.Context, subscriptionCh <-chan description.Topology, ss ServerSelector, timeoutCh <-chan time.Time) ([]description.Server, error) {
+	ctx, span := trace.SpanFromFunctionCaller(ctx)
+	defer span.End()
+
 	var current description.Topology
 	for {
 		select {

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -61,6 +61,14 @@ func RelativeName() string {
 	return relativeName(2)
 }
 
+func AnnotateStrings(span *trace.Span, message string, strMap map[string]string) {
+	var attrs []trace.Attribute
+	for key, value := range strMap {
+		attrs = append(attrs, trace.StringAttribute(key, value))
+	}
+	span.Annotate(attrs, message)
+}
+
 func relativeName(nCaller int) string {
 	pc, _, _, _ := runtime.Caller(nCaller)
 	fn := runtime.FuncForPC(pc)

--- a/mongo/collection.go
+++ b/mongo/collection.go
@@ -78,11 +78,13 @@ func (coll *Collection) InsertOne(ctx context.Context, document interface{},
 	ctx, span := trace.SpanFromFunctionCaller(ctx)
 	defer span.End()
 
+	trace.AnnotateStrings(span, "TransformDocument", nil)
 	doc, err := TransformDocument(document)
 	if err != nil {
 		return nil, err
 	}
 
+	trace.AnnotateStrings(span, "EnsureID", nil)
 	insertedID, err := ensureID(doc)
 	if err != nil {
 		return nil, err
@@ -565,19 +567,19 @@ func (coll *Collection) Find(ctx context.Context, filter interface{},
 func (coll *Collection) FindOne(ctx context.Context, filter interface{},
 	opts ...options.FindOneOptioner) *DocumentResult {
 
-	findOpts := make([]options.FindOptioner, 0, len(opts))
-	for _, opt := range opts {
-		findOpts = append(findOpts, opt.(options.FindOptioner))
-	}
-
-	findOpts = append(findOpts, Opt.Limit(1))
-
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	ctx, span := trace.SpanFromFunctionCaller(ctx)
 	defer span.End()
+
+	findOpts := make([]options.FindOptioner, 0, len(opts))
+	for _, opt := range opts {
+		findOpts = append(findOpts, opt.(options.FindOptioner))
+	}
+
+	findOpts = append(findOpts, Opt.Limit(1))
 
 	var f *bson.Document
 	var err error


### PR DESCRIPTION
The last merge from mongodb-go contained moves that
meant the old instrumentation was lost.

This code brings back the lost instrumentation.